### PR TITLE
fix: 隐藏子进程控制台 + HID Tap 日志降级，消除启动弹窗闪烁

### DIFF
--- a/src-tauri/src/bridges/xiaomi/autostart.rs
+++ b/src-tauri/src/bridges/xiaomi/autostart.rs
@@ -149,10 +149,16 @@ fn set_startup_shortcut(enable: bool) -> Result<(), String> {
             .to_string()
             .replace('\'', "''"),
     );
-    let out = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-Command", &ps])
-        .output()
-        .map_err(|e| format!("powershell: {e}"))?;
+    let out = {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        // ponytail: 隐藏控制台，避免创建自启快捷方式时闪黑框
+        std::process::Command::new("powershell")
+            .creation_flags(CREATE_NO_WINDOW)
+            .args(["-NoProfile", "-Command", &ps])
+            .output()
+    }
+    .map_err(|e| format!("powershell: {e}"))?;
     if !out.status.success() {
         return Err(format!(
             "create shortcut failed: {}",

--- a/src-tauri/src/bridges/xiaomi/conflict_guard.rs
+++ b/src-tauri/src/bridges/xiaomi/conflict_guard.rs
@@ -230,10 +230,15 @@ fn pids_holding_port(port: u16, proto: &str) -> HashSet<u32> {
         } else {
             "tcp"
         };
-        let Ok(output) = std::process::Command::new("netstat")
-            .args(["-ano", "-p", proto_arg])
-            .output()
-        else {
+        let Ok(output) = ({
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            // ponytail: 隐藏控制台，避免冲突扫描闪黑框
+            std::process::Command::new("netstat")
+                .creation_flags(CREATE_NO_WINDOW)
+                .args(["-ano", "-p", proto_arg])
+                .output()
+        }) else {
             return out;
         };
         let text = String::from_utf8_lossy(&output.stdout);

--- a/src-tauri/src/bridges/xiaomi/hid_tap_runtime.rs
+++ b/src-tauri/src/bridges/xiaomi/hid_tap_runtime.rs
@@ -150,19 +150,25 @@ fn write_verified_text(path: &Path, content: &str) -> Result<(), String> {
 fn lock_runtime_acl(path: &Path) -> Result<(), String> {
     fn apply(target: &Path, directory: bool) -> Result<(), String> {
         let suffix = if directory { "(OI)(CI)" } else { "" };
-        let output = Command::new("icacls.exe")
-            .arg(target)
-            .args([
-                "/inheritance:r",
-                "/grant:r",
-                &format!("*S-1-5-18:{suffix}F"),
-                &format!("*S-1-5-32-544:{suffix}F"),
-                &format!("*S-1-5-32-545:{suffix}RX"),
-                "/C",
-                "/Q",
-            ])
-            .output()
-            .map_err(|e| format!("icacls spawn failed: {e}"))?;
+        let output = {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            // ponytail: 隐藏控制台，避免启动时闪黑框
+            Command::new("icacls.exe")
+                .creation_flags(CREATE_NO_WINDOW)
+                .arg(target)
+                .args([
+                    "/inheritance:r",
+                    "/grant:r",
+                    &format!("*S-1-5-18:{suffix}F"),
+                    &format!("*S-1-5-32-544:{suffix}F"),
+                    &format!("*S-1-5-32-545:{suffix}RX"),
+                    "/C",
+                    "/Q",
+                ])
+                .output()
+                .map_err(|e| format!("icacls spawn failed: {e}"))?
+        };
         if !output.status.success() {
             let stdout = String::from_utf8_lossy(&output.stdout);
             return Err(format!("failed to secure Gadget runtime ACL: {}", stdout.trim()));
@@ -474,7 +480,8 @@ fn windows_find_host_pid() -> Option<u32> {
                 if pid > 0 {
                     let _ = RegCloseKey(service_key);
                     let _ = RegCloseKey(root);
-                    log::info!(
+                    // debug：hub loop 每轮重试都会调用本函数，INFO 会每秒刷屏撑爆日志文件
+                    log::debug!(
                         "XIAOMI HID TAP HostPid={pid} type={ty} service={service_name} instance={instance_name}"
                     );
                     return Some(pid);


### PR DESCRIPTION
HID Tap 附着时用 icacls 设置运行时目录 ACL、冲突扫描用 netstat、自启
快捷方式用 powershell，三个子进程均为控制台程序，未加 CREATE_NO_WINDOW
时每次启动闪 3~5 个黑框。改动：
- hid_tap_runtime lock_runtime_acl: icacls 加 CREATE_NO_WINDOW
- hid_tap_runtime windows_find_host_pid: HostPid 日志从 info 降级为 debug（ hub 循环每 2 秒调用一次，之前每秒刷屏撑爆日志文件）
- conflict_guard: netstat 加 CREATE_NO_WINDOW
- autostart: powershell 加 CREATE_NO_WINDOW